### PR TITLE
Cast NSInteger/NSUnsigned integer to avoid memory warnings

### DIFF
--- a/Source/UZKArchive.m
+++ b/Source/UZKArchive.m
@@ -1397,7 +1397,7 @@ compressionMethod:(UZKCompressionMethod)method
             break;
             
         case UZKFileModeUnassigned:
-            NSAssert(NO, @"Cannot call -openFile:inMode:withPassword:error: with a mode of UZKFileModeUnassigned (%lu)", mode);
+            NSAssert(NO, @"Cannot call -openFile:inMode:withPassword:error: with a mode of UZKFileModeUnassigned (%lu)", (unsigned long)mode);
             break;
     }
     
@@ -1463,7 +1463,7 @@ compressionMethod:(UZKCompressionMethod)method
             break;
             
         case UZKFileModeUnassigned:
-            NSAssert(NO, @"Unbalanced call to -closeFile:, openCount == %ld", self.openCount);
+            NSAssert(NO, @"Unbalanced call to -closeFile:, openCount == %ld", (long)self.openCount);
             break;
     }
     


### PR DESCRIPTION
Cast NSInteger/NSUnsigned to long and unsigned long respectively in
NSAssert to avoid compiler warnings on iOS