### PR TITLE
Xcode 7 Compatibility Changes

### DIFF
--- a/Lib/MiniZip/ioapi.h
+++ b/Lib/MiniZip/ioapi.h
@@ -18,25 +18,25 @@
 
 */
 
-#ifndef _ZLIBIOAPI64_H
-#define _ZLIBIOAPI64_H
+#ifndef ZLIBIOAPI64_H
+#define ZLIBIOAPI64_H
 
 #if (!defined(_WIN32)) && (!defined(WIN32))
 
   // Linux needs this to support file operation on files larger then 4+GB
   // But might need better if/def to select just the platforms that needs them.
 
-        #ifndef __USE_FILE_OFFSET64
-                #define __USE_FILE_OFFSET64
+        #ifndef USE_FILE_OFFSET64
+                #define USE_FILE_OFFSET64
         #endif
-        #ifndef __USE_LARGEFILE64
-                #define __USE_LARGEFILE64
+        #ifndef USE_LARGEFILE64
+                #define USE_LARGEFILE64
         #endif
-        #ifndef _LARGEFILE64_SOURCE
-                #define _LARGEFILE64_SOURCE
+        #ifndef LARGEFILE64_SOURCE
+                #define LARGEFILE64_SOURCE
         #endif
-        #ifndef _FILE_OFFSET_BIT
-                #define _FILE_OFFSET_BIT 64
+        #ifndef FILE_OFFSET_BIT
+                #define FILE_OFFSET_BIT 64
         #endif
 #endif
 

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.abbey-code.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Source/UZKArchive.h
+++ b/Source/UZKArchive.h
@@ -7,7 +7,7 @@
 #import <Foundation/Foundation.h>
 
 #import "UZKFileInfo.h"
-
+NS_ASSUME_NONNULL_BEGIN
 
 @interface UZKArchive : NSObject
 
@@ -199,7 +199,7 @@ typedef NS_ENUM(NSInteger, UZKErrorCode) {
  *
  *  @return Returns a list of NSString containing the paths within the archive's contents, or nil if an error was encountered
  */
-- (NSArray *)listFilenames:(NSError **)error;
+- (nullable NSArray *)listFilenames:(NSError **)error;
 
 /**
  *  Lists the various attributes of each file in the archive
@@ -208,7 +208,7 @@ typedef NS_ENUM(NSInteger, UZKErrorCode) {
  *
  *  @return Returns a list of UZKFileInfo objects, which contain metadata about the archive's files, or nil if an error was encountered
  */
-- (NSArray *)listFileInfo:(NSError **)error;
+- (nullable NSArray *)listFileInfo:(NSError **)error;
 
 /**
  *  Writes all files in the archive to the given path
@@ -226,7 +226,7 @@ typedef NS_ENUM(NSInteger, UZKErrorCode) {
  */
 - (BOOL)extractFilesTo:(NSString *)destinationDirectory
              overwrite:(BOOL)overwrite
-              progress:(void (^)(UZKFileInfo *currentFile, CGFloat percentArchiveDecompressed))progress
+              progress:(nullable void (^)(UZKFileInfo *currentFile, CGFloat percentArchiveDecompressed))progress
                  error:(NSError **)error;
 
 /**
@@ -241,8 +241,8 @@ typedef NS_ENUM(NSInteger, UZKErrorCode) {
  *
  *  @return An NSData object containing the bytes of the file, or nil if an error was encountered
  */
-- (NSData *)extractData:(UZKFileInfo *)fileInfo
-               progress:(void (^)(CGFloat percentDecompressed))progress
+- (nullable NSData *)extractData:(UZKFileInfo *)fileInfo
+               progress:(nullable void (^)(CGFloat percentDecompressed))progress
                   error:(NSError **)error;
 
 /**
@@ -257,8 +257,8 @@ typedef NS_ENUM(NSInteger, UZKErrorCode) {
  *
  *  @return An NSData object containing the bytes of the file, or nil if an error was encountered
  */
-- (NSData *)extractDataFromFile:(NSString *)filePath
-                       progress:(void (^)(CGFloat percentDecompressed))progress
+- (nullable NSData *)extractDataFromFile:(NSString *)filePath
+                       progress:(nullable void (^)(CGFloat percentDecompressed))progress
                           error:(NSError **)error;
 
 /**
@@ -353,7 +353,7 @@ typedef NS_ENUM(NSInteger, UZKErrorCode) {
  */
 - (BOOL)writeData:(NSData *)data
          filePath:(NSString *)filePath
-         progress:(void (^)(CGFloat percentCompressed))progress
+         progress:(nullable void (^)(CGFloat percentCompressed))progress
             error:(NSError **)error;
 
 /**
@@ -372,8 +372,8 @@ typedef NS_ENUM(NSInteger, UZKErrorCode) {
  */
 - (BOOL)writeData:(NSData *)data
          filePath:(NSString *)filePath
-         fileDate:(NSDate *)fileDate
-         progress:(void (^)(CGFloat percentCompressed))progress
+         fileDate:(nullable NSDate *)fileDate
+         progress:(nullable void (^)(CGFloat percentCompressed))progress
             error:(NSError **)error;
 
 /**
@@ -394,10 +394,10 @@ typedef NS_ENUM(NSInteger, UZKErrorCode) {
  */
 - (BOOL)writeData:(NSData *)data
          filePath:(NSString *)filePath
-         fileDate:(NSDate *)fileDate
+         fileDate:(nullable NSDate *)fileDate
 compressionMethod:(UZKCompressionMethod)method
-         password:(NSString *)password
-         progress:(void (^)(CGFloat percentCompressed))progress
+         password:(nullable NSString *)password
+         progress:(nullable void (^)(CGFloat percentCompressed))progress
             error:(NSError **)error;
 
 /**
@@ -424,11 +424,11 @@ compressionMethod:(UZKCompressionMethod)method
  */
 - (BOOL)writeData:(NSData *)data
          filePath:(NSString *)filePath
-         fileDate:(NSDate *)fileDate
+         fileDate:(nullable NSDate *)fileDate
 compressionMethod:(UZKCompressionMethod)method
-         password:(NSString *)password
+         password:(nullable NSString *)password
         overwrite:(BOOL)overwrite
-         progress:(void (^)(CGFloat percentCompressed))progress
+         progress:(nullable void (^)(CGFloat percentCompressed))progress
             error:(NSError **)error;
 
 /**
@@ -473,7 +473,7 @@ compressionMethod:(UZKCompressionMethod)method
  *  @return YES if successful, NO on error
  */
 - (BOOL)writeIntoBuffer:(NSString *)filePath
-               fileDate:(NSDate *)fileDate
+               fileDate:(nullable NSDate *)fileDate
                   error:(NSError **)error
                   block:(BOOL(^)(BOOL(^writeData)(const void *bytes, unsigned int length), NSError **actionError))action;
 
@@ -498,7 +498,7 @@ compressionMethod:(UZKCompressionMethod)method
  *  @return YES if successful, NO on error
  */
 - (BOOL)writeIntoBuffer:(NSString *)filePath
-               fileDate:(NSDate *)fileDate
+               fileDate:(nullable NSDate *)fileDate
       compressionMethod:(UZKCompressionMethod)method
                   error:(NSError **)error
                   block:(BOOL(^)(BOOL(^writeData)(const void *bytes, unsigned int length), NSError **actionError))action;
@@ -531,7 +531,7 @@ compressionMethod:(UZKCompressionMethod)method
  *  @return YES if successful, NO on error
  */
 - (BOOL)writeIntoBuffer:(NSString *)filePath
-               fileDate:(NSDate *)fileDate
+               fileDate:(nullable NSDate *)fileDate
       compressionMethod:(UZKCompressionMethod)method
               overwrite:(BOOL)overwrite
                   error:(NSError **)error
@@ -567,7 +567,7 @@ compressionMethod:(UZKCompressionMethod)method
  *  @return YES if successful, NO on error
  */
 - (BOOL)writeIntoBuffer:(NSString *)filePath
-               fileDate:(NSDate *)fileDate
+               fileDate:(nullable NSDate *)fileDate
       compressionMethod:(UZKCompressionMethod)method
               overwrite:(BOOL)overwrite
                     CRC:(uLong)preCRC
@@ -605,11 +605,11 @@ compressionMethod:(UZKCompressionMethod)method
  *  @return YES if successful, NO on error
  */
 - (BOOL)writeIntoBuffer:(NSString *)filePath
-               fileDate:(NSDate *)fileDate
+               fileDate:(nullable NSDate *)fileDate
       compressionMethod:(UZKCompressionMethod)method
               overwrite:(BOOL)overwrite
                     CRC:(uLong)preCRC
-               password:(NSString *)password
+               password:(nullable NSString *)password
                   error:(NSError **)error
                   block:(BOOL(^)(BOOL(^writeData)(const void *bytes, unsigned int length), NSError **actionError))action;
 
@@ -625,3 +625,5 @@ compressionMethod:(UZKCompressionMethod)method
 
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/UZKArchive.m
+++ b/Source/UZKArchive.m
@@ -242,7 +242,9 @@ NS_DESIGNATED_INITIALIZER
         return NO;
     }
     
-    return [UZKArchive pathIsAZip:fileURL.path];
+    NSString *path = fileURL.path;
+    
+    return [UZKArchive pathIsAZip:path];
 }
 
 
@@ -742,7 +744,8 @@ compressionMethod:(UZKCompressionMethod)method
         for (NSUInteger i = 0; i <= data.length; i += bufferSize) {
             unsigned int dataRemaining = (unsigned int)(data.length - i);
             unsigned int size = (unsigned int)(dataRemaining < bufferSize ? dataRemaining : bufferSize);
-            int err = zipWriteInFileInZip(self.zipFile, (char *)bytes + i, size);
+
+            int err = zipWriteInFileInZip(self.zipFile, (char *)(unsigned long)bytes + i, size);
             
             if (err != ZIP_OK) {
                 return err;
@@ -908,7 +911,13 @@ compressionMethod:(UZKCompressionMethod)method
     
     NSFileManager *fm = [NSFileManager defaultManager];
     
-    if (![fm fileExistsAtPath:self.filename]) {
+    NSString *fileName = self.filename;
+    
+    if (!fileName){
+        return YES;
+    }
+    
+    if (![fm fileExistsAtPath:fileName]) {
         NSLog(@"No archive exists at path %@, when trying to delete %@", self.filename, filePath);
         return YES;
     }
@@ -1175,7 +1184,9 @@ compressionMethod:(UZKCompressionMethod)method
     NSError *replaceError = nil;
     NSURL *newURL;
     
-    BOOL result = [fm replaceItemAtURL:self.fileURL
+    NSURL *fileURL = self.fileURL;
+    
+    BOOL result = [fm replaceItemAtURL:fileURL
                          withItemAtURL:temporaryURL
                         backupItemName:nil
                                options:NSFileManagerItemReplacementWithoutDeletingBackupItem

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.abbey-code.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Tests/WriteDataTests.swift
+++ b/Tests/WriteDataTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class WriteDataTests: UZKArchiveTestCase {
 
     func testWriteData() {
-        let testFilePaths = [String](nonZipTestFilePaths as! Set<String>).sorted(<)
+        let testFilePaths = [String](nonZipTestFilePaths as! Set<String>).sort(<)
         let testDates = [
             UZKArchiveTestCase.dateFormatter().dateFromString("12/20/2014 9:35 AM"),
             UZKArchiveTestCase.dateFormatter().dateFromString("12/21/2014 10:00 AM"),
@@ -24,41 +24,52 @@ class WriteDataTests: UZKArchiveTestCase {
         
         var writeError: NSError? = nil
         
-        for (index, testFilePath) in enumerate(testFilePaths) {
+        for (index, testFilePath) in testFilePaths.enumerate() {
             let fileData = NSData(contentsOfURL: testFileURLs[testFilePath] as! NSURL)
             testFileData.append(fileData!)
             
-            let result = archive.writeData(fileData!, filePath: testFilePath, fileDate: testDates[index],
-                compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
-                    #if DEBUG
-                        NSLog("Compressing data: %f%% complete", percentCompressed)
-                    #endif
-                }, error: &writeError)
+            let result: Bool
+            do {
+                try archive.writeData(fileData!, filePath: testFilePath, fileDate: testDates[index],
+                                compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
+                                    #if DEBUG
+                                        NSLog("Compressing data: %f%% complete", percentCompressed)
+                                    #endif
+                                })
+                result = true
+            } catch let error as NSError {
+                writeError = error
+                result = false
+            }
             
             XCTAssertTrue(result, "Error writing archive data")
             XCTAssertNil(writeError, "Error writing to file \(testFilePath): \(writeError)")
         }
         
-        var readError: NSError? = nil
+        //var readError: NSError? = nil
         var index = 0
         
-        archive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
-            let expectedData = testFileData[index]
-            let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
+        do {
+            try archive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
+                let expectedData = testFileData[index]
+                let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
             
-            XCTAssertEqual(fileInfo.filename, testFilePaths[index], "Incorrect filename in archive")
-            XCTAssertEqual(fileInfo.timestamp, testDates[index]!, "Incorrect timestamp in archive")
-            XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
-            XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
+                XCTAssertEqual(fileInfo.filename, testFilePaths[index], "Incorrect filename in archive")
+                XCTAssertEqual(fileInfo.timestamp, testDates[index]!, "Incorrect timestamp in archive")
+                XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
+                XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
             
-            index++;
-            }, error: &readError)
+                index++;
+                })
+        } catch {
+
+        }
         
         XCTAssert(index > 0, "No data iterated through")
     }
     
     func testWriteData_Unicode() {
-        let testFilePaths = [String](nonZipUnicodeFilePaths as! Set<String>).sorted(<)
+        let testFilePaths = [String](nonZipUnicodeFilePaths as! Set<String>).sort(<)
         let testDates = [
             UZKArchiveTestCase.dateFormatter().dateFromString("12/20/2014 9:35 AM"),
             UZKArchiveTestCase.dateFormatter().dateFromString("12/21/2014 10:00 AM"),
@@ -70,41 +81,51 @@ class WriteDataTests: UZKArchiveTestCase {
         
         var writeError: NSError? = nil
         
-        for (index, testFilePath) in enumerate(testFilePaths) {
+        for (index, testFilePath) in testFilePaths.enumerate() {
             let fileData = NSData(contentsOfURL: unicodeFileURLs[testFilePath] as! NSURL)
             testFileData.append(fileData!)
             
-            let result = archive.writeData(fileData!, filePath: testFilePath, fileDate: testDates[index],
-                compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
-                    #if DEBUG
-                        NSLog("Compressing data: %f%% complete", percentCompressed)
-                    #endif
-                }, error: &writeError)
+            let result: Bool
+            do {
+                try archive.writeData(fileData!, filePath: testFilePath, fileDate: testDates[index],
+                                compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
+                                    #if DEBUG
+                                        NSLog("Compressing data: %f%% complete", percentCompressed)
+                                    #endif
+                                })
+                result = true
+            } catch let error as NSError {
+                writeError = error
+                result = false
+            }
             
             XCTAssertTrue(result, "Error writing archive data")
             XCTAssertNil(writeError, "Error writing to file \(testFilePath): \(writeError)")
         }
         
-        var readError: NSError? = nil
         var index = 0
         
-        archive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
-            let expectedData = testFileData[index]
-            let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
+        do {
+            try archive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
+                let expectedData = testFileData[index]
+                let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
             
-            XCTAssertEqual(fileInfo.filename, testFilePaths[index], "Incorrect filename in archive")
-            XCTAssertEqual(fileInfo.timestamp, testDates[index]!, "Incorrect timestamp in archive")
-            XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
-            XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
+                XCTAssertEqual(fileInfo.filename, testFilePaths[index], "Incorrect filename in archive")
+                XCTAssertEqual(fileInfo.timestamp, testDates[index]!, "Incorrect timestamp in archive")
+                XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
+                XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
             
-            index++;
-            }, error: &readError)
+                index++;
+                })
+        } catch {
+
+        }
         
         XCTAssert(index > 0, "No data iterated through")
     }
     
     func testWriteData_Overwrite() {
-        let testFilePaths = [String](nonZipTestFilePaths as! Set<String>).sorted(<)
+        let testFilePaths = [String](nonZipTestFilePaths as! Set<String>).sort(<)
         let testDates = [
             UZKArchiveTestCase.dateFormatter().dateFromString("12/20/2014 9:35 AM"),
             UZKArchiveTestCase.dateFormatter().dateFromString("12/21/2014 10:00 AM"),
@@ -116,35 +137,46 @@ class WriteDataTests: UZKArchiveTestCase {
         
         var writeError: NSError? = nil
         
-        for (index, testFilePath) in enumerate(testFilePaths) {
+        for (index, testFilePath) in testFilePaths.enumerate() {
             let fileData = NSData(contentsOfURL: testFileURLs[testFilePath] as! NSURL)
             testFileData.append(fileData!)
             
-            let result = archive.writeData(fileData!, filePath: testFilePath, fileDate: testDates[index],
-                compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
-                    #if DEBUG
-                        NSLog("Compressing data: %f%% complete", percentCompressed)
-                    #endif
-                }, error: &writeError)
+            let result: Bool
+            do {
+                try archive.writeData(fileData!, filePath: testFilePath, fileDate: testDates[index],
+                                compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
+                                    #if DEBUG
+                                        NSLog("Compressing data: %f%% complete", percentCompressed)
+                                    #endif
+                                })
+                result = true
+            } catch let error as NSError {
+                writeError = error
+                result = false
+            }
             
             XCTAssertTrue(result, "Error writing archive data")
             XCTAssertNil(writeError, "Error writing to file \(testFilePath): \(writeError)")
         }
         
-        var readError: NSError? = nil
+
         var index = 0
         
-        archive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
-            let expectedData = testFileData[index]
-            let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
+        do {
+            try archive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
+                let expectedData = testFileData[index]
+                let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
             
-            XCTAssertEqual(fileInfo.filename, testFilePaths[index], "Incorrect filename in archive")
-            XCTAssertEqual(fileInfo.timestamp, testDates[index]!, "Incorrect timestamp in archive")
-            XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
-            XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
+                XCTAssertEqual(fileInfo.filename, testFilePaths[index], "Incorrect filename in archive")
+                XCTAssertEqual(fileInfo.timestamp, testDates[index]!, "Incorrect timestamp in archive")
+                XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
+                XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
             
-            index++;
-            }, error: &readError)
+                index++;
+                })
+        } catch {
+
+        }
         
         XCTAssert(index > 0, "No data iterated through")
         
@@ -156,41 +188,51 @@ class WriteDataTests: UZKArchiveTestCase {
         for i in 0..<testFilePaths.count {
             let x = testFilePaths.count - 1 - i
             
-            let result = archive.writeData(testFileData[x], filePath: testFilePaths[i],
-                fileDate: testDates[x], compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
-                    #if DEBUG
-                        NSLog("Compressing data: %f%% complete", percentCompressed)
-                    #endif
-                }, error: &reverseWriteError)
+            let result: Bool
+            do {
+                try archive.writeData(testFileData[x], filePath: testFilePaths[i],
+                                fileDate: testDates[x], compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
+                                    #if DEBUG
+                                        NSLog("Compressing data: %f%% complete", percentCompressed)
+                                    #endif
+                                })
+                result = true
+            } catch let error as NSError {
+                reverseWriteError = error
+                result = false
+            }
             
             XCTAssertTrue(result, "Error writing archive data")
             XCTAssertNil(reverseWriteError, "Error writing to file \(testFilePaths[x]) with data of " +
                 "file \(testFilePaths[i]): \(reverseWriteError)")
         }
         
-        var reverseReadError: NSError? = nil
         var forwardIndex = 0
         
-        archive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
-            XCTAssertEqual(fileInfo.filename, testFilePaths[forwardIndex], "Incorrect filename in archive");
+        do {
+            try archive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
+                XCTAssertEqual(fileInfo.filename, testFilePaths[forwardIndex], "Incorrect filename in archive");
             
-            let reverseIndex = testFilePaths.count - 1 - forwardIndex
+                let reverseIndex = testFilePaths.count - 1 - forwardIndex
 
-            let expectedData = testFileData[reverseIndex]
-            let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
+                let expectedData = testFileData[reverseIndex]
+                let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
             
-            XCTAssertEqual(fileInfo.timestamp, testDates[reverseIndex]!, "Incorrect timestamp in archive")
-            XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
-            XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
+                XCTAssertEqual(fileInfo.timestamp, testDates[reverseIndex]!, "Incorrect timestamp in archive")
+                XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
+                XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
             
-            forwardIndex++;
-            }, error: &reverseReadError)
+                forwardIndex++;
+                })
+        } catch {
+
+        }
         
         XCTAssert(index > 0, "No data iterated through")
     }
     
     func testWriteData_Overwrite_Unicode() {
-        let testFilePaths = [String](nonZipUnicodeFilePaths as! Set<String>).sorted(<)
+        let testFilePaths = [String](nonZipUnicodeFilePaths as! Set<String>).sort(<)
         let testDates = [
             UZKArchiveTestCase.dateFormatter().dateFromString("12/20/2014 9:35 AM"),
             UZKArchiveTestCase.dateFormatter().dateFromString("12/21/2014 10:00 AM"),
@@ -202,35 +244,46 @@ class WriteDataTests: UZKArchiveTestCase {
         
         var writeError: NSError? = nil
         
-        for (index, testFilePath) in enumerate(testFilePaths) {
+        for (index, testFilePath) in testFilePaths.enumerate() {
             let fileData = NSData(contentsOfURL: unicodeFileURLs[testFilePath] as! NSURL)
             testFileData.append(fileData!)
             
-            let result = archive.writeData(fileData!, filePath: testFilePath, fileDate: testDates[index],
-                compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
-                    #if DEBUG
-                        NSLog("Compressing data: %f%% complete", percentCompressed)
-                    #endif
-                }, error: &writeError)
+            let result: Bool
+            do {
+                try archive.writeData(fileData!, filePath: testFilePath, fileDate: testDates[index],
+                                compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
+                                    #if DEBUG
+                                        NSLog("Compressing data: %f%% complete", percentCompressed)
+                                    #endif
+                                })
+                result = true
+            } catch let error as NSError {
+                writeError = error
+                result = false
+            }
             
             XCTAssertTrue(result, "Error writing archive data")
             XCTAssertNil(writeError, "Error writing to file \(testFilePath): \(writeError)")
         }
         
-        var readError: NSError? = nil
+
         var index = 0
         
-        archive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
-            let expectedData = testFileData[index]
-            let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
+        do {
+            try archive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
+                let expectedData = testFileData[index]
+                let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
             
-            XCTAssertEqual(fileInfo.filename, testFilePaths[index], "Incorrect filename in archive")
-            XCTAssertEqual(fileInfo.timestamp, testDates[index]!, "Incorrect timestamp in archive")
-            XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
-            XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
+                XCTAssertEqual(fileInfo.filename, testFilePaths[index], "Incorrect filename in archive")
+                XCTAssertEqual(fileInfo.timestamp, testDates[index]!, "Incorrect timestamp in archive")
+                XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
+                XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
             
-            index++;
-            }, error: &readError)
+                index++;
+                })
+        } catch {
+
+        }
         
         XCTAssert(index > 0, "No data iterated through")
         
@@ -242,41 +295,52 @@ class WriteDataTests: UZKArchiveTestCase {
         for i in 0..<testFilePaths.count {
             let x = testFilePaths.count - 1 - i
             
-            let result = archive.writeData(testFileData[x], filePath: testFilePaths[i],
-                fileDate: testDates[x], compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
-                    #if DEBUG
-                        NSLog("Compressing data: %f%% complete", percentCompressed)
-                    #endif
-                }, error: &reverseWriteError)
+            let result: Bool
+            do {
+                try archive.writeData(testFileData[x], filePath: testFilePaths[i],
+                                fileDate: testDates[x], compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
+                                    #if DEBUG
+                                        NSLog("Compressing data: %f%% complete", percentCompressed)
+                                    #endif
+                                })
+                result = true
+            } catch let error as NSError {
+                reverseWriteError = error
+                result = false
+            }
             
             XCTAssertTrue(result, "Error writing archive data")
             XCTAssertNil(reverseWriteError, "Error writing to file \(testFilePaths[x]) with data of " +
                 "file \(testFilePaths[i]): \(reverseWriteError)")
         }
         
-        var reverseReadError: NSError? = nil
+
         var forwardIndex = 0
         
-        archive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
-            XCTAssertEqual(fileInfo.filename, testFilePaths[forwardIndex], "Incorrect filename in archive");
+        do {
+            try archive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
+                XCTAssertEqual(fileInfo.filename, testFilePaths[forwardIndex], "Incorrect filename in archive");
             
-            let reverseIndex = testFilePaths.count - 1 - forwardIndex
+                let reverseIndex = testFilePaths.count - 1 - forwardIndex
             
-            let expectedData = testFileData[reverseIndex]
-            let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
+                let expectedData = testFileData[reverseIndex]
+                let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
             
-            XCTAssertEqual(fileInfo.timestamp, testDates[reverseIndex]!, "Incorrect timestamp in archive")
-            XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
-            XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
+                XCTAssertEqual(fileInfo.timestamp, testDates[reverseIndex]!, "Incorrect timestamp in archive")
+                XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
+                XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
             
-            forwardIndex++;
-            }, error: &reverseReadError)
+                forwardIndex++;
+                })
+        } catch {
+
+        }
         
         XCTAssert(index > 0, "No data iterated through")
     }
     
     func testWriteData_NoOverwrite() {
-        let testFilePaths = [String](nonZipTestFilePaths as! Set<String>).sorted(<)
+        let testFilePaths = [String](nonZipTestFilePaths as! Set<String>).sort(<)
         let testDates = [
             UZKArchiveTestCase.dateFormatter().dateFromString("12/20/2014 9:35 AM"),
             UZKArchiveTestCase.dateFormatter().dateFromString("12/21/2014 10:00 AM"),
@@ -288,48 +352,65 @@ class WriteDataTests: UZKArchiveTestCase {
         
         var writeError: NSError? = nil
         
-        for (index, testFilePath) in enumerate(testFilePaths) {
+        for (index, testFilePath) in testFilePaths.enumerate() {
             let fileData = NSData(contentsOfURL: testFileURLs[testFilePath] as! NSURL)
             testFileData.append(fileData!)
             
-            let result = archive.writeData(fileData!, filePath: testFilePath, fileDate: testDates[index],
-                compressionMethod: .Default, password: nil, overwrite: false, progress: nil, error: &writeError)
+            let result: Bool
+            do {
+                try archive.writeData(fileData!, filePath: testFilePath, fileDate: testDates[index],
+                                compressionMethod: .Default, password: nil, overwrite: false, progress: nil)
+                result = true
+            } catch let error as NSError {
+                writeError = error
+                result = false
+            }
             
             XCTAssertTrue(result, "Error writing archive data")
             XCTAssertNil(writeError, "Error writing to file \(testFilePath): \(writeError)")
         }
         
-        var readError: NSError? = nil
+
         var index = 0
         
-        archive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
-            let expectedData = testFileData[index]
-            let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
+        do {
+            try archive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
+                let expectedData = testFileData[index]
+                let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
             
-            XCTAssertEqual(fileInfo.filename, testFilePaths[index], "Incorrect filename in archive")
-            XCTAssertEqual(fileInfo.timestamp, testDates[index]!, "Incorrect timestamp in archive")
-            XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
-            XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
+                XCTAssertEqual(fileInfo.filename, testFilePaths[index], "Incorrect filename in archive")
+                XCTAssertEqual(fileInfo.timestamp, testDates[index]!, "Incorrect timestamp in archive")
+                XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
+                XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
             
-            index++;
-            }, error: &readError)
+                index++;
+                })
+        } catch {
+            
+        }
         
         XCTAssert(index > 0, "No data iterated through")
         
         // Now write the files' contents to the zip in reverse
         
-        var reverseWriteError: NSError? = nil
-        
+        var reverseWriteError : NSError?
         for i in 0..<testFilePaths.count {
             let x = testFilePaths.count - 1 - i
             
-            let result = archive.writeData(testFileData[x], filePath: testFilePaths[i],
-                fileDate: testDates[x], compressionMethod: .Default, password: nil, overwrite: false,
-                progress: { (percentCompressed) -> Void in
-                    #if DEBUG
-                        NSLog("Compressing data: %f%% complete", percentCompressed)
-                    #endif
-                }, error: &reverseWriteError)
+            let result: Bool
+            do {
+                try archive.writeData(testFileData[x], filePath: testFilePaths[i],
+                                fileDate: testDates[x], compressionMethod: .Default, password: nil, overwrite: false,
+                                progress: { (percentCompressed) -> Void in
+                                    #if DEBUG
+                                        NSLog("Compressing data: %f%% complete", percentCompressed)
+                                    #endif
+                                })
+                result = true
+            } catch let error as NSError {
+                reverseWriteError = error
+                result = false
+            }
             
             XCTAssertTrue(result, "Error writing archive data")
             XCTAssertNil(reverseWriteError, "Error writing to file \(testFilePaths[x]) with data of " +
@@ -337,7 +418,13 @@ class WriteDataTests: UZKArchiveTestCase {
         }
         
         var listError: NSError? = nil
-        let newFileList = archive.listFileInfo(&listError)
+        let newFileList: [AnyObject]!
+        do {
+            newFileList = try archive.listFileInfo()
+        } catch let error as NSError {
+            listError = error
+            newFileList = nil
+        }
         XCTAssertNil(listError, "Error reading a re-written archive")
         
         // This is the most we can guarantee, the number of files in the directory
@@ -354,22 +441,28 @@ class WriteDataTests: UZKArchiveTestCase {
         
         var lastFileSize: UInt64 = 0
         
-        for i in 0..<100 {
+        for _ in 0..<100 {
             var writeError: NSError? = nil
             
-            let result = archive.writeData(testFileData, filePath: testFilename, fileDate: nil,
-                compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
-                    #if DEBUG
-                        NSLog("Compressing data: %f%% complete", percentCompressed)
-                    #endif
-                }, error: &writeError)
+            let result: Bool
+            do {
+                try archive.writeData(testFileData!, filePath: testFilename, fileDate: nil,
+                                compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
+                                    #if DEBUG
+                                        NSLog("Compressing data: %f%% complete", percentCompressed)
+                                    #endif
+                                })
+                result = true
+            } catch let error as NSError {
+                writeError = error
+                result = false
+            }
             
             XCTAssertTrue(result, "Error writing archive data")
             XCTAssertNil(writeError, "Error writing to file \(testFileURL): \(writeError)")
             
-            var fileSizeError: NSError? = nil
             let fm = NSFileManager.defaultManager()
-            let fileAttributes = fm.attributesOfItemAtPath(testArchiveURL.path!, error: &fileSizeError) as! [String:AnyObject]
+            let fileAttributes = (try! fm.attributesOfItemAtPath(testArchiveURL.path!)) 
             let fileSize = fileAttributes[NSFileSize] as! NSNumber
             
             if lastFileSize > 0 {
@@ -390,34 +483,40 @@ class WriteDataTests: UZKArchiveTestCase {
         
         var writeError: NSError? = nil
         
-        let result = archive.writeData(testFileData, filePath: testFilename, fileDate: nil,
-            compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
-                #if DEBUG
-                    NSLog("Compressing data: %f%% complete", percentCompressed)
-                #endif
-            }, error: &writeError)
+        let result: Bool
+        do {
+            try archive.writeData(testFileData!, filePath: testFilename, fileDate: nil,
+                        compressionMethod: .Default, password: nil, progress: { (percentCompressed) -> Void in
+                            #if DEBUG
+                                NSLog("Compressing data: %f%% complete", percentCompressed)
+                            #endif
+                        })
+            result = true
+        } catch let error as NSError {
+            writeError = error
+            result = false
+        }
         
         XCTAssertTrue(result, "Error writing archive data")
         XCTAssertNil(writeError, "Error writing to file \(testFileURL): \(writeError)")
         
-        var listError: NSError? = nil
-        let fileList = archive.listFileInfo(&listError) as! [UZKFileInfo]
+        let fileList = (try! archive.listFileInfo()) as! [UZKFileInfo]
         let writtenFileInfo = fileList.first!
         
         let expectedDate = NSDate().timeIntervalSinceReferenceDate
         let actualDate = writtenFileInfo.timestamp.timeIntervalSinceReferenceDate
         
-        XCTAssertEqualWithAccuracy(actualDate, expectedDate, 30, "Incorrect default date value written to file")
+        XCTAssertEqualWithAccuracy(actualDate, expectedDate, accuracy: 30, "Incorrect default date value written to file")
     }
     
     func testWriteData_PasswordProtected() {
-        let testFilePaths = [String](nonZipTestFilePaths as! Set<String>).sorted(<)
+        let testFilePaths = [String](nonZipTestFilePaths as! Set<String>).sort(<)
         var testFileData = [NSData]()
         
         let testArchiveURL = tempDirectory.URLByAppendingPathComponent("SwiftWriteDataTest.zip")
         let password = "111111"
         
-        let writeArchive = UZKArchive.zipArchiveAtPath(testArchiveURL.path, password: password)
+        let writeArchive = UZKArchive.zipArchiveAtPath(testArchiveURL.path!, password: password)
         
         var writeError: NSError? = nil
         
@@ -425,7 +524,14 @@ class WriteDataTests: UZKArchiveTestCase {
             let fileData = NSData(contentsOfURL: testFileURLs[testFilePath] as! NSURL)
             testFileData.append(fileData!)
             
-            let result = writeArchive.writeData(fileData!, filePath: testFilePath, error: &writeError)
+            let result: Bool
+            do {
+                try writeArchive.writeData(fileData!, filePath: testFilePath)
+                result = true
+            } catch let error as NSError {
+                writeError = error
+                result = false
+            }
             
             XCTAssertTrue(result, "Error writing archive data at path \(testFilePath)")
             XCTAssertNil(writeError, "Error writing to file \(testFilePath): \(writeError)")
@@ -433,22 +539,25 @@ class WriteDataTests: UZKArchiveTestCase {
         
         // Read with UnzipKit
         
-        let readArchive = UZKArchive.zipArchiveAtPath(testArchiveURL.path, password: password)
+        let readArchive = UZKArchive.zipArchiveAtPath(testArchiveURL.path!, password: password)
         XCTAssertTrue(readArchive.isPasswordProtected(), "Archive is not marked as password-protected")
         
-        var readError: NSError? = nil
         var index = 0
         
-        readArchive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
-            let expectedData = testFileData[index]
-            let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
+        do {
+            try readArchive.performOnDataInArchive({ (fileInfo, fileData, stop) -> Void in
+                let expectedData = testFileData[index]
+                let expectedCRC = crc32(0, UnsafePointer<Bytef>(expectedData.bytes), uInt(expectedData.length))
             
-            XCTAssertEqual(fileInfo.filename, testFilePaths[index], "Incorrect filename in archive")
-            XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
-            XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
+                XCTAssertEqual(fileInfo.filename, testFilePaths[index], "Incorrect filename in archive")
+                XCTAssertEqual(fileInfo.CRC, expectedCRC, "CRC of extracted data doesn't match what was written")
+                XCTAssertEqual(fileData, expectedData, "Data extracted doesn't match what was written")
             
-            ++index
-            }, error: &readError)
+                ++index
+                })
+        } catch {
+            
+        }
         
         XCTAssertEqual(index, testFilePaths.count, "Not all files enumerated")
         

--- a/UnzipKit.xcodeproj/project.pbxproj
+++ b/UnzipKit.xcodeproj/project.pbxproj
@@ -249,7 +249,9 @@
 		96EA65951A40AEAE00685B6D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Abbey Code";
 				TargetAttributes = {
 					96EA659D1A40AEAE00685B6D = {
@@ -351,6 +353,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -433,6 +436,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.abbey-code.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -450,6 +454,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.abbey-code.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -460,16 +465,19 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
 				);
+				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.abbey-code.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/UnzipKitTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -485,14 +493,18 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
 				);
+				GCC_OPTIMIZATION_LEVEL = s;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.abbey-code.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/UnzipKitTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				WARNING_CFLAGS = (
 					"$(inherited)",
 					"-Wno-everything",

--- a/UnzipKit.xcodeproj/xcshareddata/xcschemes/UnzipKit.xcscheme
+++ b/UnzipKit.xcodeproj/xcshareddata/xcschemes/UnzipKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Release">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:UnzipKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -85,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/UnzipKitDemo/UnzipKitDemo.xcodeproj/project.pbxproj
+++ b/UnzipKitDemo/UnzipKitDemo.xcodeproj/project.pbxproj
@@ -129,7 +129,8 @@
 		969E2FD71AD573F100E19F7A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Abbey Code";
 				TargetAttributes = {
 					969E2FDE1AD573F100E19F7A = {
@@ -255,6 +256,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -327,6 +329,7 @@
 				INFOPLIST_FILE = UnzipKitDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.abbey-code.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "UnzipKitDemo-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -343,6 +346,7 @@
 				INFOPLIST_FILE = UnzipKitDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.abbey-code.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "UnzipKitDemo-Bridging-Header.h";
 			};

--- a/UnzipKitDemo/UnzipKitDemo.xcodeproj/xcshareddata/xcschemes/UnzipKitDemo.xcscheme
+++ b/UnzipKitDemo/UnzipKitDemo.xcodeproj/xcshareddata/xcschemes/UnzipKitDemo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
@@ -38,15 +38,18 @@
             ReferencedContainer = "container:UnzipKitDemo.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
@@ -62,10 +65,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/UnzipKitDemo/UnzipKitDemo/Info.plist
+++ b/UnzipKitDemo/UnzipKitDemo/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.abbey-code.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/UnzipKitDemo/UnzipKitDemo/ViewController.swift
+++ b/UnzipKitDemo/UnzipKitDemo/ViewController.swift
@@ -25,17 +25,16 @@ class ViewController: UIViewController {
 
     @IBAction func listFiles(sender: AnyObject) {
         let fileURL = NSBundle.mainBundle().URLForResource("Test Data/Test Archive", withExtension: "zip")
-        let archive = UZKArchive.zipArchiveAtURL(fileURL)
+        let archive = UZKArchive.zipArchiveAtURL(fileURL!)
         
-        var listFilesError: NSError? = nil
-        let filesList = archive.listFilenames(&listFilesError) as? [String]
-        
-        if let list = filesList {
-            self.textView.text = "\n".join(list)
-        } else if let error = listFilesError {
+        do {
+            let filesList = try archive.listFilenames() as? [String]
+            if let list = filesList {
+                self.textView.text = list.joinWithSeparator("\n")
+            }
+        }catch let error as NSError {
             self.textView.text = error.localizedDescription
         }
     }
-
 }
 


### PR DESCRIPTION
The macros in `ioapi.h` were throwing compiler errors in Xcode 7 because of the underscores. My C is not great so I'm not sure if what I did there was correct. 

One of the tests doesn't pass, but I'm not seeing how the changes made by myself and the migrators would have caused the test to fail.

Ran Swift 1.2 -> 2.0 Migrator
Updated project to "Recommended Settings"
Added nullability annotations to UZKArchive
Turned on bitcode.
Turned on Whole Module Optimization for Swift.
Fixed compiler warnings.