### PR TITLE
Reduced memory usage by reading files using extractBufferedDataFromFile…

### DIFF
--- a/Source/UZKArchive.h
+++ b/Source/UZKArchive.h
@@ -114,10 +114,6 @@ typedef NS_ENUM(NSInteger, UZKErrorCode) {
      *  The CRC given up front doesn't match the calculated CRC
      */
     UZKErrorCodePreCRCMismatch = 114,
-    /**
-     *  The CRC given up front doesn't match the calculated CRC
-     */
-    UZKErrorCodeFileHandleCreate = 115,
 };
 
 /**

--- a/Source/UZKArchive.h
+++ b/Source/UZKArchive.h
@@ -114,6 +114,10 @@ typedef NS_ENUM(NSInteger, UZKErrorCode) {
      *  The CRC given up front doesn't match the calculated CRC
      */
     UZKErrorCodePreCRCMismatch = 114,
+    /**
+     *  The CRC given up front doesn't match the calculated CRC
+     */
+    UZKErrorCodeFileHandleCreate = 115,
 };
 
 /**

--- a/Source/UZKArchive.m
+++ b/Source/UZKArchive.m
@@ -473,9 +473,12 @@ NS_DESIGNATED_INITIALIZER
 
 					
 					if (!extractSuccess) {
-						[self assignError:&strongError code:UZKErrorCodeOutputError
-								   detail:[NSString localizedStringWithFormat:NSLocalizedString(@"Error extracting current file (%d) '%@'", @"Detailed error string"),
-										   strongError, info.filename]];
+						[self assignError:&strongError code:strongError.code
+								   detail:strongError.localizedDescription];
+                        
+                        // Remove the directory we were going to unzip to if it fails.
+                        [fm removeItemAtURL:defalatedDirectoryURL
+                                      error:nil];
 						return;
 					}
 					

--- a/Source/UZKArchive.m
+++ b/Source/UZKArchive.m
@@ -461,8 +461,8 @@ NS_DESIGNATED_INITIALIZER
 
 					
                     if (!deflatedFileHandle) {
-                        [self assignError:&strongError code:UZKErrorCodeFileHandleCreate
-                                   detail:[NSString localizedStringWithFormat:NSLocalizedString(@"Error creating file handle for writing to URL: %@", @"Detailed error string"),
+                        [self assignError:&strongError code:UZKErrorCodeOutputError
+                                   detail:[NSString localizedStringWithFormat:NSLocalizedString(@"Error writing to file: %@", @"Detailed error string"),
                                            deflatedFileURL]];
                         return;
                     }

--- a/Source/UZKArchive.m
+++ b/Source/UZKArchive.m
@@ -455,19 +455,22 @@ NS_DESIGNATED_INITIALIZER
 										   strongError, info.filename]];
 						return;
 					}
-					
-					__block double dataLength = 0;
-					
-					NSError *handleError = nil;
+										
 					NSFileHandle *deflatedFileHandle = [NSFileHandle fileHandleForWritingToURL:deflatedFileURL
-																			   error:&handleError];
+                                                                                         error:&strongError];
 
 					
+                    if (!deflatedFileHandle) {
+                        [self assignError:&strongError code:UZKErrorCodeFileHandleCreate
+                                   detail:[NSString localizedStringWithFormat:NSLocalizedString(@"Error creating file handle for writing to URL: %@", @"Detailed error string"),
+                                           deflatedFileURL]];
+                        return;
+                    }
+                    
 					BOOL extractSuccess = [self extractBufferedDataFromFile:info.filename
 																  error:&strongError
 																 action:
 									^(NSData *dataChunk, CGFloat percentDecompressed) {
-										dataLength += dataChunk.length;
                                         bytesDecompressed += dataChunk.length;
 										[deflatedFileHandle writeData:dataChunk];
                                         if (progress) {

--- a/Tests/WriteDataTests.swift
+++ b/Tests/WriteDataTests.swift
@@ -8,6 +8,7 @@
 
 import Cocoa
 import XCTest
+import UnzipKit
 
 class WriteDataTests: UZKArchiveTestCase {
 


### PR DESCRIPTION
… instead of readFile. Addresses #27

Files were previously read whole into memory and then written out. This change streams them instead, reducing the amount of memory required to unzip files.