### PR TITLE
Fix crash in extractBufferedDataFromFile:error:action:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added support for `NSProgress` and `NSProgressReporting` in all extraction and iteration methods (Issue #32)
 * Added detailed logging using new unified logging framework. See [the readme](README.md) for more details (Issue #47)
+* Fixed a crasher in `extractBufferedDataFromFile:error:action:`, which also manifested in other methods that use it, like `validatePassword` (Issue #51 - Thanks, [@amosavian](https://github.com/amosavian)!)
 * Upgraded project to Xcode 9 and to the macOS 10.13 and iOS 11 SDKs (Issue #61)
 * Consolidated targets so they're shared between iOS and macOS (Issue #62)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Added support for `NSProgress` and `NSProgressReporting` in all extraction and iteration methods (Issue #32)
 * Added detailed logging using new unified logging framework. See [the readme](README.md) for more details (Issue #47)
-* Fixed a crasher in `extractBufferedDataFromFile:error:action:`, which also manifested in other methods that use it, like `validatePassword` (Issue #51 - Thanks, [@amosavian](https://github.com/amosavian)!)
+* Fixed a crasher in `extractBufferedDataFromFile:error:action:`, which also manifested in other methods that use it, like `validatePassword` (Issue #51 - Thanks, [@amosavian](https://github.com/amosavian), [@monobono](https://github.com/monobono), and [@segunlee](https://github.com/segunlee)!)
 * Upgraded project to Xcode 9 and to the macOS 10.13 and iOS 11 SDKs (Issue #61)
 * Consolidated targets so they're shared between iOS and macOS (Issue #62)
 

--- a/Scripts/carthage-validate.sh
+++ b/Scripts/carthage-validate.sh
@@ -1,8 +1,23 @@
 #!/bin/bash
 
+REPO="github \"$TRAVIS_REPO_SLUG\""
+COMMIT=$TRAVIS_COMMIT
+
 if [ -z ${TRAVIS+x} ]; then
+    REPO="git \"`pwd`\""
+    COMMIT=`git log -1 --oneline | cut -f1 -d' '`
     TRAVIS_BUILD_DIR="/Users/Dov/Source Code/UnzipKit"
-    TRAVIS_BRANCH=`git rev-parse --abbrev-ref HEAD` #Current Git branch
+    echo "Not running in Travis. Setting REPO ($REPO) and COMMIT ($COMMIT)"
+fi
+
+if [ -n "$TRAVIS" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    REPO="github \"$TRAVIS_PULL_REQUEST_SLUG\""
+    COMMIT=$TRAVIS_PULL_REQUEST_SHA
+    echo "Build is for a Pull Request. Overriding REPO ($REPO) and COMMIT ($COMMIT)"
+fi
+
+if [ ! -d "CarthageValidation" ]; then
+    mkdir "CarthageValidation"
 fi
 
 brew install carthage
@@ -11,7 +26,7 @@ rm UnzipKitDemo/Cartfile
 rm UnzipKitDemo/Cartfile.resolved
 rm -rf UnzipKitDemo/Carthage
 
-echo "git \"$TRAVIS_BUILD_DIR\" \"$TRAVIS_BRANCH\"" > UnzipKitDemo/Cartfile
+echo "$REPO \"$COMMIT\"" > UnzipKitDemo/Cartfile
 
 pushd UnzipKitDemo > /dev/null
 

--- a/Source/UZKArchive.m
+++ b/Source/UZKArchive.m
@@ -861,6 +861,8 @@ NS_DESIGNATED_INITIALIZER
         
         long long bytesDecompressed = 0;
         
+        NSError *strongInnerError = nil;
+        
         for (;;)
         {
             if (progress.isCancelled) {
@@ -877,9 +879,9 @@ NS_DESIGNATED_INITIALIZER
                     NSString *detail = [NSString localizedStringWithFormat:NSLocalizedStringFromTableInBundle(@"Failed to read file %@ in zip", @"UnzipKit", _resources, @"Detailed error string"),
                                         info.filename];
                     UZKLogError("Error reading data (code %d): %{public}@", bytesRead, detail);
-                    [welf assignError:innerError code:bytesRead
+                    [welf assignError:&strongInnerError code:bytesRead
                                detail:detail];
-                    return;
+                    break;
                 }
                 else if (bytesRead == 0) {
                     UZKLogDebug("Done reading file");
@@ -898,6 +900,11 @@ NS_DESIGNATED_INITIALIZER
                 
                 progress.completedUnitCount = bytesDecompressed;
             }
+        }
+        
+        if (strongInnerError) {
+            *innerError = strongInnerError;
+            return;
         }
         
         UZKLogInfo("Closing file...");

--- a/Tests/ExtractFilesTests.m
+++ b/Tests/ExtractFilesTests.m
@@ -230,14 +230,6 @@
     
     BOOL success = [archive extractFilesTo:extractURL.path
                                  overwrite:NO
-                                  progress:
-# if DEBUG
-                    ^(UZKFileInfo *currentFile, CGFloat percentArchiveDecompressed) {
-                        UZKLogDebug("Extracting %@: %f%% complete", currentFile.filename, percentArchiveDecompressed * 100);
-                    }
-# else
-                    nil
-# endif
                                      error:&error];
     
     XCTAssertTrue(success, @"Extract large Zip64 archive failed");
@@ -280,14 +272,6 @@
     
     BOOL success = [archive extractFilesTo:extractURL.path
                                  overwrite:NO
-                                  progress:
-# if DEBUG
-                    ^(UZKFileInfo *currentFile, CGFloat percentArchiveDecompressed) {
-                        UZKLogDebug("Extracting %@: %f%% complete", currentFile.filename, percentArchiveDecompressed * 100);
-                    }
-# else
-                    nil
-# endif
                                      error:&error];
     
     XCTAssertTrue(success, @"Extract numerous Zip64 archive failed");

--- a/Tests/PasswordProtectionTests.m
+++ b/Tests/PasswordProtectionTests.m
@@ -107,7 +107,7 @@
 }
 
 #if !TARGET_OS_IPHONE
-- (void)testValidatePassword_Issue51
+- (void)testValidatePassword_LargeFile
 {
     NSString *password = @"12345-luggage";
     

--- a/Tests/PasswordProtectionTests.m
+++ b/Tests/PasswordProtectionTests.m
@@ -106,19 +106,23 @@
     XCTAssertTrue(archive.validatePassword, @"validatePassword = NO when password supplied");
 }
 
+#if !TARGET_OS_IPHONE
 - (void)testValidatePassword_Issue51
 {
+    NSString *password = @"12345-luggage";
+    
+    NSArray<NSURL*> *urls = @[[self emptyTextFileOfLength:400000]];
+    NSURL *archiveURL = [self archiveWithFiles:urls password:password];
+
     NSError *error = nil;
-    
-    NSURL *archiveURL = self.testFileURLs[@"Test Archive (Password).zip"];
-    
     UZKArchive *archive = [[UZKArchive alloc] initWithURL:archiveURL error:&error];
     
-    if (![archive validatePassword]) {
-        // Do nothing. test passes
-    } else {
-        XCTAssert(NO, @"Password validation fails");
-    }
+    XCTAssertNotNil(archive, @"Archive not initialized");
+    XCTAssertNil(error, @"Error initializing archive: %@", error);
+    
+    BOOL passwordValidated = [archive validatePassword];
+    XCTAssertFalse(passwordValidated, @"Expected password to be reported as incorrect");
 }
+#endif
 
 @end

--- a/Tests/PasswordProtectionTests.m
+++ b/Tests/PasswordProtectionTests.m
@@ -106,5 +106,19 @@
     XCTAssertTrue(archive.validatePassword, @"validatePassword = NO when password supplied");
 }
 
+- (void)testValidatePassword_Issue51
+{
+    NSError *error = nil;
+    
+    NSURL *archiveURL = self.testFileURLs[@"Test Archive (Password).zip"];
+    
+    UZKArchive *archive = [[UZKArchive alloc] initWithURL:archiveURL error:&error];
+    
+    if (![archive validatePassword]) {
+        // Do nothing. test passes
+    } else {
+        XCTAssert(NO, @"Password validation fails");
+    }
+}
 
 @end

--- a/Tests/UZKArchiveTestCase.h
+++ b/Tests/UZKArchiveTestCase.h
@@ -43,6 +43,7 @@
 #if !TARGET_OS_IPHONE
 - (NSInteger)numberOfOpenFileHandles;
 - (NSURL *)archiveWithFiles:(NSArray *)fileURLs;
+- (NSURL *)archiveWithFiles:(NSArray *)fileURLs password:(NSString *)password;
 - (BOOL)extractArchive:(NSURL *)url password:(NSString *)password;
 - (NSURL *)largeArchive;
 #endif


### PR DESCRIPTION
Fixed a weak error pointer inside of an `@autoreleasepool` in `extractBufferedDataFromFile:error:action:`, addressing issue #51. Also added a regression test case for it.