### PR TITLE
Fixing few bugs

### DIFF
--- a/Source/UZKArchive.m
+++ b/Source/UZKArchive.m
@@ -495,6 +495,9 @@ NS_DESIGNATED_INITIALIZER
 
                     [deflatedFileHandle closeFile];
                     
+                    NSDictionary* attribs = [NSDictionary dictionaryWithObjectsAndKeys:info.timestamp, NSFileModificationDate, nil];
+                    [[NSFileManager defaultManager] setAttributes:attribs ofItemAtPath:path error:nil];
+                    
                     if (!extractSuccess) {
                         [self assignError:&strongError code:strongError.code
                                    detail:strongError.localizedDescription];


### PR DESCRIPTION
Changes:
- Extracting files with correct modification date instead of extracting time.
- Addressing #74 : Empty folders does not exist after unpacking.
- Fixed a crash when an error occurs in a file with size bigger than buffer size, related to autoreleasepool.
- Increased Buffer size: Progress handler may cause congestion due to relatively small size if progress handler updates UI. This change will make UI updating much more smoother.