### PR TITLE
Fix Issue #91

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.0
 
 * Removed methods deprecated in v1.9 (Issue #90, PR #92)
+* Fixed behavior of `-extractFilesTo:overwrite:error:`, so it shows the progress of each individual file as they extract (Issue #91, PR #94)
 
 ## 1.9
 

--- a/Source/UZKArchive.m
+++ b/Source/UZKArchive.m
@@ -567,6 +567,8 @@ NS_DESIGNATED_INITIALIZER
                         return;
                     }
                     
+                    [progress becomeCurrentWithPendingUnitCount:info.uncompressedSize];
+                    
                     UZKLogDebug("Extracting buffered data");
                     BOOL extractSuccess = [welf extractBufferedDataFromFile:info.filename
                                                                   error:&strongError
@@ -576,6 +578,8 @@ NS_DESIGNATED_INITIALIZER
                                         bytesDecompressed += dataChunk.length;
                                         [deflatedFileHandle writeData:dataChunk];
                                     }];
+                    
+                    [progress resignCurrent];
 
                     UZKLogDebug("Closing file handle");
                     [deflatedFileHandle closeFile];
@@ -599,7 +603,6 @@ NS_DESIGNATED_INITIALIZER
                                          forKey:NSProgressFileCompletedCountKey];
                     [progress setUserInfoObject:@(fileInfo.count)
                                          forKey:NSProgressFileTotalCountKey];
-                    progress.completedUnitCount = bytesDecompressed;
                 }
             }
         }

--- a/Source/UZKArchive.m
+++ b/Source/UZKArchive.m
@@ -1025,16 +1025,6 @@ compressionMethod:(UZKCompressionMethod)method
 compressionMethod:(UZKCompressionMethod)method
          password:(NSString *)password
         overwrite:(BOOL)overwrite
-            error:(NSError * __autoreleasing*)error
-{
-    return [self writeData:data
-                  filePath:filePath
-                  fileDate:fileDate
-          posixPermissions:0
-         compressionMethod:method
-                  password:password
-                 overwrite:overwrite
-                     error:error];
 }
 
 - (BOOL)writeData:(NSData *)data

--- a/Source/UZKArchive.m
+++ b/Source/UZKArchive.m
@@ -1025,6 +1025,16 @@ compressionMethod:(UZKCompressionMethod)method
 compressionMethod:(UZKCompressionMethod)method
          password:(NSString *)password
         overwrite:(BOOL)overwrite
+            error:(NSError * __autoreleasing*)error
+{
+    return [self writeData:data
+                  filePath:filePath
+                  fileDate:fileDate
+          posixPermissions:0
+         compressionMethod:method
+                  password:password
+                 overwrite:overwrite
+                     error:error];
 }
 
 - (BOOL)writeData:(NSData *)data

--- a/beta-notes.md
+++ b/beta-notes.md
@@ -1,1 +1,2 @@
 * Removed methods deprecated in v1.9 (Issue #90, PR #92)
+* Fixed behavior of `-extractFilesTo:overwrite:error:`, so it shows the progress of each individual file as they extract (Issue #91, PR #94)


### PR DESCRIPTION
Fixes the `-extractFilesTo:overwrite:error:` implementation so it reports the progress of each file as its extracted