### PR TITLE
Fixed crasher in `+pathIsAZip:` (Issue #99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Removed methods deprecated in v1.9 (Issue #90, PR #92)
 * Fixed behavior of `-extractFilesTo:overwrite:error:`, so it shows the progress of each individual file as they extract (Issue #91, PR #94)
 * Deprecated the initializers that take a file path instead of an `NSURL` (Issue #90, PR #95)
+* Fixed a crasher for unreadable files in `+pathIsAZip:` (Issue #99)
 
 ## 1.9
 

--- a/Source/UZKArchive.m
+++ b/Source/UZKArchive.m
@@ -311,6 +311,9 @@ NS_DESIGNATED_INITIALIZER
 
         UZKLogDebug("File is not a ZIP. Unknown contents in 3rd and 4th bytes (%02X %02X)", dataBytes[2], dataBytes[3]);
     }
+    @catch (NSException *e) {
+        UZKLogError("Error checking if %{public}@ is a Zip archive: %{public}@", filePath, e);
+    }
     @finally {
         [handle closeFile];
     }


### PR DESCRIPTION
Catches the exception and logs it, instead of letting it propagate.